### PR TITLE
Fixes in Undo redo

### DIFF
--- a/src/processing/UndoRedo.java
+++ b/src/processing/UndoRedo.java
@@ -252,6 +252,10 @@ public class UndoRedo {
     */
    public static void pushIntoStack(BoardObject object) {
 	   
+	   //If the object is created by other user then do not push it into the stack
+	   if (object.getUserId().equals(ClientBoardState.userId) == false)
+		   return;
+	   
 	   // pushes into undo stack
 	   addIntoStack(ClientBoardState.undoStack, object);
 	   /** 

--- a/src/processing/UndoRedo.java
+++ b/src/processing/UndoRedo.java
@@ -79,7 +79,7 @@ public class UndoRedo {
 				obj.getObjectId(),
 				obj.getTimestamp(),
 				obj.getUserId(),
-				false
+				obj.isResetObject()
 				);
 				
 		//sets the CREATE operation in the created object


### PR DESCRIPTION
Now, other user's object can't be pushed into the stack and during object creation, object's reset is used.