### PR TITLE
Delete Fix - not using selectedObject if it's null

### DIFF
--- a/src/processing/SelectDelete.java
+++ b/src/processing/SelectDelete.java
@@ -90,7 +90,7 @@ public class SelectDelete {
          * make selectedObject null and send empty list as selected pixels to UI
          */
         PriorityQueueObject selectedObject = ClientBoardState.getSelectedObject();
-        if (selectedObject.objectId == object.getObjectId()) {
+        if ((selectedObject != null) && (selectedObject.objectId == object.getObjectId())) {
             ClientBoardState.setSelectedObject(null);
             CommunicateChange.identifierToHandler
                     .get(CommunicateChange.identifierUI)


### PR DESCRIPTION
Check if selectedObject is null before using its id